### PR TITLE
Define cross-accelerator reproduction scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ environment, policy seed, control budget, solver budget, solver batch size,
 and protocol mode. MuJoCo, Pymunk, dm-control, Gymnasium, PyTorch, CUDA, cuDNN,
 task source, checkpoint source, and evaluator source are fingerprinted.
 
+Exact episode reproduction is claimed only inside one physics, execution, and
+numerical fingerprint. A fixed-protocol rerun on another GPU architecture is a
+cross-numerics sensitivity result, not a failed exact reproduction. CLEAR does
+not use a universal cross-accelerator SR tolerance; use the paired comparison
+tool and report all three policy seeds. See
+[`docs/RUNTIME_REPRODUCIBILITY.md`](docs/RUNTIME_REPRODUCIBILITY.md).
+
 The pinned official source revisions and hashes are in
 [`checkpoints/official-v0.5.json`](checkpoints/official-v0.5.json). Binary
 weights and datasets remain outside ordinary Git.

--- a/clear_lewm/environment.py
+++ b/clear_lewm/environment.py
@@ -5,6 +5,7 @@ import importlib.util
 import json
 import os
 import platform
+import subprocess
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
@@ -38,6 +39,14 @@ EVALUATION_RUNTIME_MODULES = {
     "cem": "stable_worldmodel.solver.cem",
     "checkpoint_loader": "stable_worldmodel.wm.utils",
 }
+
+CLEAR_RUNTIME_FILES = (
+    "metrics.py",
+    "protocols.py",
+    "runner.py",
+    "tasks.py",
+    "tworoom_runtime.py",
+)
 
 # SHA-256 values from the stable-worldmodel 0.1.0 wheel published on PyPI.
 OFFICIAL_RUNTIME_HASHES = {
@@ -86,6 +95,67 @@ def _module_source(module_name: str) -> dict:
 def _environment_source(task: str | None) -> dict | None:
     module_name = TASK_ENVIRONMENT_MODULES.get(task or "")
     return _module_source(module_name) if module_name is not None else None
+
+
+def _clear_lewm_source_audit() -> dict:
+    root = Path(__file__).resolve().parent
+    return {
+        name: hashlib.sha256((root / name).read_bytes()).hexdigest()
+        for name in CLEAR_RUNTIME_FILES
+    }
+
+
+def _nvidia_driver_version() -> str | None:
+    try:
+        completed = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=driver_version",
+                "--format=csv,noheader",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    versions = {line.strip() for line in completed.stdout.splitlines() if line.strip()}
+    return ",".join(sorted(versions)) or None
+
+
+def _torch_numerical_controls(torch_module) -> dict:
+    cuda_backend = getattr(torch_module.backends, "cuda", None)
+
+    def cuda_flag(name: str):
+        value = getattr(cuda_backend, name, None) if cuda_backend is not None else None
+        return value() if callable(value) else None
+
+    return {
+        "float32_matmul_precision": torch_module.get_float32_matmul_precision(),
+        "deterministic_algorithms": (
+            torch_module.are_deterministic_algorithms_enabled()
+        ),
+        "deterministic_algorithms_warn_only": (
+            torch_module.is_deterministic_algorithms_warn_only_enabled()
+        ),
+        "cudnn_benchmark": torch_module.backends.cudnn.benchmark,
+        "cudnn_deterministic": torch_module.backends.cudnn.deterministic,
+        "cudnn_allow_tf32": torch_module.backends.cudnn.allow_tf32,
+        "cuda_matmul_allow_tf32": torch_module.backends.cuda.matmul.allow_tf32,
+        "flash_sdp_enabled": cuda_flag("flash_sdp_enabled"),
+        "mem_efficient_sdp_enabled": cuda_flag("mem_efficient_sdp_enabled"),
+        "math_sdp_enabled": cuda_flag("math_sdp_enabled"),
+        "cudnn_sdp_enabled": cuda_flag("cudnn_sdp_enabled"),
+        "environment": {
+            name: os.environ.get(name)
+            for name in (
+                "CUBLAS_WORKSPACE_CONFIG",
+                "CUDA_MODULE_LOADING",
+                "NVIDIA_TF32_OVERRIDE",
+            )
+        },
+    }
 
 
 def stable_worldmodel_source_audit() -> dict:
@@ -152,6 +222,8 @@ def collect_environment(torch_module=None, task: str | None = None) -> dict:
     numerics = {
         "numpy": packages["numpy"],
         "python": platform.python_version(),
+        "python_compiler": platform.python_compiler(),
+        "python_implementation": platform.python_implementation(),
         "task": task,
         "scipy": packages["scipy"],
         "torch": packages["torch"],
@@ -173,8 +245,12 @@ def collect_environment(torch_module=None, task: str | None = None) -> dict:
                 "name": properties.name,
                 "compute_capability": [properties.major, properties.minor],
                 "total_memory_bytes": properties.total_memory,
+                "driver_version": _nvidia_driver_version(),
             }
             numerics["accelerator"] = accelerator
+        numerics["torch_controls"] = _torch_numerical_controls(torch_module)
+
+    clear_sources = _clear_lewm_source_audit()
 
     record = {
         "python": platform.python_version(),
@@ -184,6 +260,7 @@ def collect_environment(torch_module=None, task: str | None = None) -> dict:
         "physics": physics,
         "numerics": numerics,
         "execution": execution,
+        "clear_lewm_execution_sources": clear_sources,
         "accelerator": accelerator,
         "rendering": {
             "mujoco_gl": os.environ.get("MUJOCO_GL"),
@@ -192,5 +269,10 @@ def collect_environment(torch_module=None, task: str | None = None) -> dict:
     }
     record["physics_fingerprint"] = _fingerprint(physics)
     record["numerics_fingerprint"] = _fingerprint(numerics)
-    record["execution_fingerprint"] = _fingerprint(execution["sources"])
+    record["execution_fingerprint"] = _fingerprint(
+        {
+            "stable_worldmodel": execution["sources"],
+            "clear_lewm": clear_sources,
+        }
+    )
     return record

--- a/clear_lewm/reproduction.py
+++ b/clear_lewm/reproduction.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+
+from .metrics import bootstrap_ci
+
+CORE_IDENTITY_FIELDS = {
+    "task": ("task",),
+    "protocol": ("protocol",),
+    "manifest_sha256": ("manifest_sha256",),
+    "policy_seed": ("policy_seed",),
+    "dataset_fingerprint": ("dataset_fingerprint",),
+    "checkpoint_runtime_sha256": ("checkpoint", "runtime_sha256"),
+    "checkpoint_config_sha256": ("checkpoint", "config_sha256"),
+    "solver": ("solver",),
+    "inference": ("inference",),
+    "cpu_threads": ("runtime", "cpu_threads"),
+    "float32_matmul_precision": (
+        "runtime",
+        "float32_matmul_precision",
+    ),
+}
+
+ENVIRONMENT_FIELDS = {
+    "physics_fingerprint": ("environment", "physics_fingerprint"),
+    "execution_fingerprint": ("environment", "execution_fingerprint"),
+    "numerics_fingerprint": ("environment", "numerics_fingerprint"),
+}
+
+
+def _load_result(path: str | Path) -> dict:
+    path = Path(path)
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, dict):
+        raise ValueError(f"CLEAR result must be a JSON object: {path}")
+    if payload.get("schema_version") != "clear-lewm-result-v1":
+        raise ValueError(f"Unsupported CLEAR result schema: {path}")
+    return payload
+
+
+def _nested(payload: dict, path: tuple[str, ...]):
+    value = payload
+    for key in path:
+        if not isinstance(value, dict) or key not in value:
+            return None
+        value = value[key]
+    return value
+
+
+def _identity_checks(reference: dict, candidate: dict) -> dict:
+    fields = {**CORE_IDENTITY_FIELDS, **ENVIRONMENT_FIELDS}
+    return {
+        label: {
+            "match": _nested(reference, path) == _nested(candidate, path),
+            "reference": _nested(reference, path),
+            "candidate": _nested(candidate, path),
+        }
+        for label, path in fields.items()
+    }
+
+
+def _exact_mcnemar_pvalue(reference_only: int, candidate_only: int) -> float:
+    discordant = reference_only + candidate_only
+    if discordant == 0:
+        return 1.0
+    tail = sum(
+        math.comb(discordant, value)
+        for value in range(min(reference_only, candidate_only) + 1)
+    ) / (2**discordant)
+    return min(1.0, 2.0 * tail)
+
+
+def _paired_outcomes(reference: dict, candidate: dict) -> dict:
+    reference_trace = np.asarray(reference.get("episode_successes"), dtype=bool)
+    candidate_trace = np.asarray(candidate.get("episode_successes"), dtype=bool)
+    if reference_trace.ndim != 1 or candidate_trace.ndim != 1:
+        raise ValueError("episode_successes must be one-dimensional in both results")
+    if len(reference_trace) == 0 or len(reference_trace) != len(candidate_trace):
+        raise ValueError("Results must contain equally sized, non-empty episode traces")
+
+    both_success = int(np.logical_and(reference_trace, candidate_trace).sum())
+    reference_only = int(np.logical_and(reference_trace, ~candidate_trace).sum())
+    candidate_only = int(np.logical_and(~reference_trace, candidate_trace).sum())
+    both_fail = int(np.logical_and(~reference_trace, ~candidate_trace).sum())
+    paired_delta = candidate_trace.astype(float) - reference_trace.astype(float)
+    low, high = bootstrap_ci(paired_delta, seed=0, samples=10_000)
+    episodes = len(reference_trace)
+
+    return {
+        "episodes": episodes,
+        "reference_success_rate_percent": float(reference_trace.mean() * 100.0),
+        "candidate_success_rate_percent": float(candidate_trace.mean() * 100.0),
+        "candidate_minus_reference_pp": float(paired_delta.mean() * 100.0),
+        "paired_delta_ci95_pp": [low * 100.0, high * 100.0],
+        "both_success": both_success,
+        "reference_only": reference_only,
+        "candidate_only": candidate_only,
+        "both_fail": both_fail,
+        "trace_agreement_percent": float(
+            (both_success + both_fail) / episodes * 100.0
+        ),
+        "exact_mcnemar_pvalue": _exact_mcnemar_pvalue(
+            reference_only, candidate_only
+        ),
+    }
+
+
+def compare_reproduction_results(
+    reference_path: str | Path,
+    candidate_path: str | Path,
+) -> dict:
+    reference_path = Path(reference_path)
+    candidate_path = Path(candidate_path)
+    reference = _load_result(reference_path)
+    candidate = _load_result(candidate_path)
+    checks = _identity_checks(reference, candidate)
+    core_match = all(checks[label]["match"] for label in CORE_IDENTITY_FIELDS)
+    physics_match = checks["physics_fingerprint"]["match"]
+    execution_match = checks["execution_fingerprint"]["match"]
+    numerics_match = checks["numerics_fingerprint"]["match"]
+    paired = _paired_outcomes(reference, candidate)
+
+    if not core_match or not physics_match or not execution_match:
+        classification = "incompatible"
+        expectation = "Results do not share the fixed evaluation identity."
+    elif not numerics_match:
+        classification = "cross-numerics-sensitivity"
+        expectation = (
+            "The fixed protocol matches, but exact episode reproduction is not "
+            "claimed across numerical fingerprints."
+        )
+    elif paired["trace_agreement_percent"] == 100.0:
+        classification = "exact-reproduction"
+        expectation = "Fixed identity and all episode outcomes match exactly."
+    else:
+        classification = "same-runtime-drift"
+        expectation = (
+            "Numerical identity matches but episode outcomes drifted; investigate "
+            "unrecorded state or nondeterministic execution."
+        )
+
+    return {
+        "schema_version": "clear-lewm-reproduction-comparison-v1",
+        "reference": str(reference_path),
+        "candidate": str(candidate_path),
+        "classification": classification,
+        "expectation": expectation,
+        "identity_checks": checks,
+        "paired_outcomes": paired,
+    }

--- a/docs/RUNTIME_REPRODUCIBILITY.md
+++ b/docs/RUNTIME_REPRODUCIBILITY.md
@@ -15,10 +15,66 @@ Small floating-point differences can change CEM candidate ranking and amplify
 into a different closed-loop trajectory. Physics equality is necessary, but a
 paper-quality matched comparison should also use one numerical fingerprint.
 
+## Reproduction classes
+
+CLEAR distinguishes three cases rather than applying one success-rate tolerance
+to all reruns:
+
+| Class | Required identity | Interpretation |
+|---|---|---|
+| Exact reproduction | protocol, data, checkpoint, solver, physics, execution, and numerical fingerprints | all episode outcomes should match; drift is an error to investigate |
+| Cross-numerics sensitivity | all fixed identity fields match except the numerical fingerprint | valid portability evidence, but not an exact reproduction claim |
+| Incompatible | protocol, data, checkpoint, solver, physics, or execution differs | do not attribute the delta to numerical hardware |
+
+There is no universal `+/- N pp` acceptance threshold across accelerators.
+Standard CEM is a discontinuous optimizer: a small cost perturbation can change
+an elite boundary, every later proposal, and the simulated trajectory. The
+correct report is the three-seed aggregate plus paired episode transitions, not
+an architecture-independent bitwise promise.
+
+Compare a candidate result with the checked-in reference trace using:
+
+```bash
+python scripts/compare_reproduction_results.py \
+  results/v0.5/tworoom-strict-official-lewm-seed0-n100.json \
+  /path/to/local/tworoom-strict-official-lewm-seed0-n100.json \
+  --output /tmp/tworoom-seed0-comparison.json
+```
+
+The report includes identity checks, both-success/both-fail counts, directional
+episode flips, a paired bootstrap interval, and an exact McNemar p-value.
+
+## Cross-accelerator diagnostic
+
+Issue #3 supplied a complete v0.5 Strict rerun on an RTX 4090 D. Its fixed
+inputs and execution sources match the H200 reference, while its numerical
+fingerprint differs. We independently isolated the boundary under Python
+3.10.20 and PyTorch 2.6.0+cu124:
+
+- H200 and RTX 4090 generated identical raw CUDA `torch.randn` streams for all
+  30 CEM rounds at policy seeds 0, 1, and 42;
+- two RTX 4090 devices repeated the same representative FP32 GEMM bit for bit;
+- the same GEMM differed between RTX 4090 and H200, even with float32 matmul
+  precision set to `highest`.
+
+This rules out CEM RNG drift in that diagnostic and demonstrates the mechanism
+that can perturb elite ranking across Ada and Hopper. Reproduce the diagnostic
+on another accelerator with:
+
+```bash
+python scripts/audit_cross_accelerator_numerics.py --seed 0
+```
+
+Enabling deterministic PyTorch algorithms can constrain repeated execution on a
+supported stack. It does not promise identical floating-point results across
+GPU architectures.
+
 Every new CLEAR result records physics, numerical, and execution fingerprints,
 all relevant package versions, the MuJoCo runtime version, CUDA/cuDNN builds,
-accelerator properties, and the source hashes of the world loop, policy, CEM,
-and checkpoint loader. Audit a result directory with:
+the NVIDIA driver, accelerator properties, PyTorch determinism/TF32/SDP
+controls, relevant CUDA environment variables, and the source hashes of the
+world loop, policy, CEM, checkpoint loader, and CLEAR evaluation path. Audit a
+result directory with:
 
 ```bash
 python scripts/audit_result_environments.py results/run \

--- a/docs/SUBMITTING_RESULTS.md
+++ b/docs/SUBMITTING_RESULTS.md
@@ -25,10 +25,15 @@ a stable URL, revision, license, and SHA-256 where applicable.
 |---|---|
 | `self-reported` | JSON structure, canonical manifest, trace arithmetic, hashes, and provenance pass CI |
 | `reproducible` | the submission also provides public code, a checkpoint, and an exact evaluation command |
-| `maintainer-verified` | a CLEAR-LeWM maintainer independently reran the submitted revision and matched the declared result within the protocol's deterministic contract |
+| `maintainer-verified` | a CLEAR-LeWM maintainer independently reran the submitted revision inside the declared numerical fingerprint and matched every episode outcome |
 
 Authors may request the first two levels. Only maintainers assign
 `maintainer-verified` after reproduction.
+
+A rerun on a different numerical fingerprint can be published as portability or
+sensitivity evidence, but it does not earn `maintainer-verified` for the
+declared result. CLEAR intentionally does not replace this rule with an
+architecture-independent SR tolerance.
 
 ## Fixed comparison contract
 

--- a/scripts/audit_cross_accelerator_numerics.py
+++ b/scripts/audit_cross_accelerator_numerics.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Fingerprint the seeded CEM noise stream and a representative CUDA GEMM."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+
+
+def _tensor_sha256(tensor) -> str:
+    values = tensor.detach().cpu().contiguous().numpy()
+    return hashlib.sha256(values.tobytes()).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--cem-rounds", type=int, default=30)
+    parser.add_argument("--num-samples", type=int, default=300)
+    parser.add_argument("--horizon", type=int, default=5)
+    parser.add_argument("--action-dim", type=int, default=10)
+    parser.add_argument("--matmul-precision", default="highest")
+    args = parser.parse_args()
+
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("A CUDA accelerator is required")
+
+    generator = torch.Generator(device="cuda").manual_seed(args.seed)
+    noise_hashes = []
+    for _ in range(args.cem_rounds):
+        noise = torch.randn(
+            1,
+            args.num_samples,
+            args.horizon,
+            args.action_dim,
+            generator=generator,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        noise_hashes.append(_tensor_sha256(noise))
+
+    torch.manual_seed(20260827)
+    left = torch.randn(300, 768, dtype=torch.float32)
+    right = torch.randn(768, 3072, dtype=torch.float32)
+    torch.set_float32_matmul_precision(args.matmul_precision)
+    product = left.cuda() @ right.cuda()
+    properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    report = {
+        "schema_version": "clear-lewm-cross-accelerator-numerics-v1",
+        "accelerator": {
+            "name": properties.name,
+            "compute_capability": [properties.major, properties.minor],
+        },
+        "torch": torch.__version__,
+        "cuda_runtime": torch.version.cuda,
+        "matmul_precision": torch.get_float32_matmul_precision(),
+        "cem_noise": {
+            "seed": args.seed,
+            "rounds": args.cem_rounds,
+            "num_samples": args.num_samples,
+            "horizon": args.horizon,
+            "action_dim": args.action_dim,
+            "round_hashes_sha256": hashlib.sha256(
+                "".join(noise_hashes).encode()
+            ).hexdigest(),
+        },
+        "representative_fp32_gemm": {
+            "shape": [[300, 768], [768, 3072]],
+            "sha256": _tensor_sha256(product),
+            "sum_float64": float(product.double().sum().cpu()),
+            "absmax": float(product.abs().max().cpu()),
+        },
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compare_reproduction_results.py
+++ b/scripts/compare_reproduction_results.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Classify and compare two CLEAR result files episode by episode."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from clear_lewm.reproduction import compare_reproduction_results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reference", type=Path)
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    report = compare_reproduction_results(args.reference, args.candidate)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(rendered, end="")
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered)
+
+    failed = report["classification"] in {"incompatible", "same-runtime-drift"}
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -24,6 +24,14 @@ def test_environment_record_covers_task_physics_and_numerics():
         "policy",
         "world",
     }
+    assert set(record["clear_lewm_execution_sources"]) == {
+        "metrics.py",
+        "protocols.py",
+        "runner.py",
+        "tasks.py",
+        "tworoom_runtime.py",
+    }
+    assert "python_compiler" in record["numerics"]
 
 
 def test_official_runtime_audit_rejects_source_drift(monkeypatch):

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import copy
+import json
+
+from clear_lewm.reproduction import compare_reproduction_results
+
+
+def _result() -> dict:
+    return {
+        "schema_version": "clear-lewm-result-v1",
+        "task": "tworoom",
+        "protocol": {"name": "strict"},
+        "manifest_sha256": "manifest",
+        "policy_seed": 0,
+        "dataset_fingerprint": {"kind": "metadata-sha256", "value": "data"},
+        "checkpoint": {
+            "runtime_sha256": "weights",
+            "config_sha256": "config",
+        },
+        "solver": {"batch_size": 1, "num_samples": 300, "n_steps": 30},
+        "inference": {"mode": "pure-cem"},
+        "runtime": {
+            "cpu_threads": 1,
+            "float32_matmul_precision": "highest",
+        },
+        "environment": {
+            "physics_fingerprint": "physics",
+            "execution_fingerprint": "execution",
+            "numerics_fingerprint": "h200",
+        },
+        "episode_successes": [True, True, False, False],
+    }
+
+
+def _compare(tmp_path, reference: dict, candidate: dict) -> dict:
+    reference_path = tmp_path / "reference.json"
+    candidate_path = tmp_path / "candidate.json"
+    reference_path.write_text(json.dumps(reference))
+    candidate_path.write_text(json.dumps(candidate))
+    return compare_reproduction_results(reference_path, candidate_path)
+
+
+def test_exact_reproduction_requires_trace_identity(tmp_path):
+    reference = _result()
+    report = _compare(tmp_path, reference, copy.deepcopy(reference))
+    assert report["classification"] == "exact-reproduction"
+    assert report["paired_outcomes"]["trace_agreement_percent"] == 100.0
+
+
+def test_cross_numerics_is_classified_as_sensitivity_run(tmp_path):
+    reference = _result()
+    candidate = copy.deepcopy(reference)
+    candidate["environment"]["numerics_fingerprint"] = "ada"
+    candidate["episode_successes"] = [True, False, True, False]
+
+    report = _compare(tmp_path, reference, candidate)
+    assert report["classification"] == "cross-numerics-sensitivity"
+    paired = report["paired_outcomes"]
+    assert paired["reference_only"] == 1
+    assert paired["candidate_only"] == 1
+    assert paired["exact_mcnemar_pvalue"] == 1.0
+
+
+def test_same_runtime_trace_drift_is_an_error_classification(tmp_path):
+    reference = _result()
+    candidate = copy.deepcopy(reference)
+    candidate["episode_successes"][0] = False
+    report = _compare(tmp_path, reference, candidate)
+    assert report["classification"] == "same-runtime-drift"
+
+
+def test_protocol_identity_mismatch_is_incompatible(tmp_path):
+    reference = _result()
+    candidate = copy.deepcopy(reference)
+    candidate["manifest_sha256"] = "other"
+    report = _compare(tmp_path, reference, candidate)
+    assert report["classification"] == "incompatible"


### PR DESCRIPTION
## What

- classify result comparisons as exact reproduction, cross-numerics sensitivity, same-runtime drift, or incompatible
- add paired episode diagnostics with directional flips, bootstrap CI, and exact McNemar p-value
- record NVIDIA driver, PyTorch determinism/TF32/SDP controls, CUDA environment controls, and CLEAR evaluator source hashes
- add a cross-accelerator CEM-noise/GEMM diagnostic and document the scope of the reproducibility contract

## Independent diagnosis

Under Python 3.10.20 and PyTorch 2.6.0+cu124, H200 and RTX 4090 produced identical raw CUDA `torch.randn` streams for all 30 CEM rounds at seeds 0, 1, and 42. Two RTX 4090 devices also reproduced the representative FP32 GEMM bit for bit. The same GEMM differed between RTX 4090 and H200 with matmul precision `highest`.

This isolates the reported boundary: the seeded proposal stream is stable, while cross-architecture floating-point kernels can perturb CEM costs, elite ranking, later proposals, and closed-loop trajectories. A cross-numerics rerun is therefore useful sensitivity evidence, but it is not an exact episode-reproduction claim. No universal cross-accelerator SR tolerance is introduced.

## Validation

- `ruff check .`
- `pytest`: 58 passed
- checked-in TwoRoom Strict seed-0 result self-comparison: exact reproduction, 100% trace agreement
- live H200 provenance collection including driver/backend controls and CLEAR source hashes

Closes #3