### PR TITLE
Add configurable planners and a DINO-WM optimizer profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,15 +212,22 @@ Canonical v0.8 reference runs use pure CEM with `--actor-warmstart off`; no
 alternative inference contract is mixed into the reference table.
 
 The upstream LeWM Adam planner can be selected explicitly with
-`--planner adam`. Omitting `--planner` preserves the canonical CEM default.
-Alternative planners are useful for robustness studies but are not canonical
-v0.8 reference runs.
+`--planner adam`. CLEAR applies a narrow compatibility adapter for
+`stable-worldmodel==0.1.0`: a full-horizon initialization is moved to the
+solver device before CUDA sample noise is added. Omitting `--planner` preserves
+the canonical CEM default. Alternative planners are experimental/non-reference
+profiles for robustness studies, not canonical v0.8 reference runs.
 
-`--planner dinowm-gd` reproduces DINO-WM's action optimization profile: random
-normal initialization, 1,000 manual SGD updates at learning rate 1, Gaussian
-action noise 0.003, and terminal visual-latent MSE with mean reduction. LeWM has
-no separate DINO-WM proprioceptive latent head, so this adapter applies the
-paper's visual term only. Use `--n-steps` for shorter diagnostic runs.
+`--planner dinowm-gd` applies DINO-WM's **optimizer profile to LeWM visual
+latents**: random-normal initialization, 1,000 manual SGD updates at learning
+rate 1, Gaussian action noise 0.003, and terminal visual-latent MSE with mean
+reduction. It does not reproduce the DINO-WM model: the adapter has neither the
+DINO encoder contract nor DINO-WM's proprioceptive objective. Actor-prior
+initialization is unsupported; an explicit `--actor-warmstart on` is rejected.
+The default `auto` setting resolves to `off` for this planner. Use `--n-steps`
+for shorter diagnostic runs. Result JSON records the initialization, source
+revision, model scope, finite-value checks, and aggregate solver runtime. No
+performance advantage is claimed.
 
 ## Audited FAST training I/O
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ The upstream LeWM Adam planner can be selected explicitly with
 Alternative planners are useful for robustness studies but are not canonical
 v0.8 reference runs.
 
+`--planner dinowm-gd` reproduces DINO-WM's action optimization profile: random
+normal initialization, 1,000 manual SGD updates at learning rate 1, Gaussian
+action noise 0.003, and terminal visual-latent MSE with mean reduction. LeWM has
+no separate DINO-WM proprioceptive latent head, so this adapter applies the
+paper's visual term only. Use `--n-steps` for shorter diagnostic runs.
+
 ## Audited FAST training I/O
 
 FAST is an optional derived reader, not a new dataset. It decodes once into

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ clear-lewm evaluate \
 Canonical v0.8 reference runs use pure CEM with `--actor-warmstart off`; no
 alternative inference contract is mixed into the reference table.
 
+The upstream LeWM Adam planner can be selected explicitly with
+`--planner adam`. Omitting `--planner` preserves the canonical CEM default.
+Alternative planners are useful for robustness studies but are not canonical
+v0.8 reference runs.
+
 ## Audited FAST training I/O
 
 FAST is an optional derived reader, not a new dataset. It decodes once into

--- a/clear_lewm/adam.py
+++ b/clear_lewm/adam.py
@@ -1,0 +1,85 @@
+"""Compatibility adapter for stable-worldmodel 0.1.0's Adam planner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from stable_worldmodel.solver import GradientSolver
+
+UPSTREAM_ADAM_SOURCE = {
+    "package": "stable-worldmodel",
+    "version": "0.1.0",
+    "class": "stable_worldmodel.solver.GradientSolver",
+}
+
+
+class DeviceSafeGradientSolver(GradientSolver):
+    """Keep full-horizon initialization on the configured solver device.
+
+    ``stable-worldmodel==0.1.0`` only moves the initial action tensor when it
+    has to append a missing tail. Its ``prepare_init_action`` helper normally
+    returns a full-horizon CPU tensor, so CUDA sampling then mixes CPU actions
+    with CUDA noise. This adapter changes only that initialization boundary.
+    """
+
+    def init_action(
+        self, n_envs: int, actions: torch.Tensor | None = None
+    ) -> None:
+        if actions is None:
+            actions = torch.zeros(
+                (n_envs, 0, self.action_dim),
+                device=self.device,
+                dtype=self.dtype,
+            )
+        else:
+            actions = actions.to(device=self.device, dtype=self.dtype)
+
+        remaining = self.horizon - actions.shape[1]
+        if remaining > 0:
+            tail = torch.zeros(
+                n_envs,
+                remaining,
+                self.action_dim,
+                device=self.device,
+                dtype=self.dtype,
+            )
+            actions = torch.cat((actions, tail), dim=1)
+
+        actions = actions.unsqueeze(1).repeat_interleave(
+            self.num_samples, dim=1
+        )
+        actions[:, 1:] += (
+            torch.randn(
+                actions[:, 1:].shape,
+                generator=self.torch_gen,
+                device=self.device,
+                dtype=self.dtype,
+            )
+            * self.var_scale
+        )
+
+        if hasattr(self, "init") and self.init.shape == actions.shape:
+            self.init.copy_(actions)
+        else:
+            if "init" in self._parameters:
+                del self._parameters["init"]
+            self.register_parameter("init", torch.nn.Parameter(actions))
+
+
+def solver_provenance() -> dict[str, Any]:
+    """Describe the narrow compatibility change applied to upstream Adam."""
+    return {
+        "source": UPSTREAM_ADAM_SOURCE,
+        "compatibility_adapter": (
+            "move full-horizon initialization to the solver device before "
+            "CUDA sample noise"
+        ),
+    }
+
+
+__all__ = [
+    "DeviceSafeGradientSolver",
+    "UPSTREAM_ADAM_SOURCE",
+    "solver_provenance",
+]

--- a/clear_lewm/cli.py
+++ b/clear_lewm/cli.py
@@ -8,7 +8,7 @@ from .audit import audit_dataset
 from .manifests import generate_manifest, save_manifest
 from .metrics import load_success_trace, summarize_success
 from .protocols import PROTOCOLS, TASKS
-from .runner import evaluate_manifest
+from .runner import PLANNERS, evaluate_manifest
 from .submissions import validate_submission
 
 
@@ -88,12 +88,18 @@ def build_parser() -> argparse.ArgumentParser:
     evaluate.add_argument("--n-steps", type=int)
     evaluate.add_argument("--topk", type=int)
     evaluate.add_argument(
+        "--planner",
+        choices=PLANNERS,
+        default="cem",
+        help="world-model planner configuration (default: cem)",
+    )
+    evaluate.add_argument(
         "--actor-warmstart",
         choices=("auto", "on", "off"),
         default="auto",
         help=(
-            "control action-prior initialization for CEM; use 'off' for "
-            "audited pure-CEM"
+            "control action-prior initialization for planning; use 'off' for "
+            "planning without a learned action prior"
         ),
     )
     evaluate.add_argument(
@@ -111,7 +117,7 @@ def build_parser() -> argparse.ArgumentParser:
     evaluate.add_argument(
         "--solver-batch-size",
         type=int,
-        help="CEM environments per GPU batch; default 1 reproduces upstream",
+        help="planning environments per GPU batch; default 1 reproduces upstream",
     )
     evaluate.add_argument(
         "--cpu-threads",
@@ -200,6 +206,7 @@ def main(argv: list[str] | None = None) -> int:
             actor_warmstart=(
                 None if args.actor_warmstart == "auto" else args.actor_warmstart == "on"
             ),
+            planner=args.planner,
             inference_mode=args.inference_mode,
             direct_target_mode=args.direct_target_mode,
             random_results=args.random_results,

--- a/clear_lewm/dinowm_gd.py
+++ b/clear_lewm/dinowm_gd.py
@@ -1,4 +1,4 @@
-"""DINO-WM's manual-SGD action planner for the CLEAR solver interface."""
+"""DINO-WM optimizer profile adapted to LeWM visual latents."""
 
 from __future__ import annotations
 
@@ -64,7 +64,12 @@ def install_terminal_latent_mean_criterion(model: Any) -> None:
 
 
 class DINOWMGDPlanner(torch.nn.Module):
-    """Adapt DINO-WM's manual SGD update to stable-worldmodel's Solver API."""
+    """Apply DINO-WM's manual SGD update to a LeWM-compatible model.
+
+    This is an optimizer-profile adapter, not a reproduction of the DINO-WM
+    model. It has neither DINO-WM's encoder contract nor its proprioceptive
+    objective.
+    """
 
     def __init__(
         self,
@@ -99,6 +104,10 @@ class DINOWMGDPlanner(torch.nn.Module):
         except (AttributeError, StopIteration):
             self._dtype = torch.float32
         self._configured = False
+        self._solve_calls = 0
+        self._total_solve_time_s = 0.0
+        self._finite_actions = True
+        self._finite_costs = True
 
     def configure(self, *, action_space: Any, n_envs: int, config: Any) -> None:
         shape = tuple(action_space.shape)
@@ -224,10 +233,29 @@ class DINOWMGDPlanner(torch.nn.Module):
             selected.append(actions.detach()[:, 0].cpu())
             histories.append(history)
 
+        actions_out = torch.cat(selected, dim=0)
+        solve_time_s = time.perf_counter() - started
+        self._solve_calls += 1
+        self._total_solve_time_s += solve_time_s
+        self._finite_actions = self._finite_actions and bool(
+            torch.isfinite(actions_out).all()
+        )
+        self._finite_costs = self._finite_costs and bool(
+            np.isfinite(np.asarray(histories, dtype=np.float64)).all()
+        )
         return {
-            "actions": torch.cat(selected, dim=0),
+            "actions": actions_out,
             "cost": histories,
-            "solve_time_s": time.perf_counter() - started,
+            "solve_time_s": solve_time_s,
+        }
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return compact finite-value and timing telemetry for provenance."""
+        return {
+            "solve_calls": self._solve_calls,
+            "total_solve_time_s": self._total_solve_time_s,
+            "finite_actions": self._finite_actions,
+            "finite_costs": self._finite_costs,
         }
 
 

--- a/clear_lewm/dinowm_gd.py
+++ b/clear_lewm/dinowm_gd.py
@@ -1,0 +1,230 @@
+"""DINO-WM's manual-SGD action planner for the CLEAR solver interface."""
+
+from __future__ import annotations
+
+import time
+from types import MethodType
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as functional
+
+DINO_WM_SOURCE = {
+    "repository": "https://github.com/gaoyuezhou/dino_wm",
+    "commit": "0a9492fa12044b852ae9e001cc74604b79c8bb0c",
+    "planner_file": "planning/gd.py",
+    "objective_file": "planning/objectives.py",
+}
+
+
+def solver_config() -> dict[str, Any]:
+    """Return the published DINO-WM GD defaults in Hydra-compatible form."""
+    return {
+        "_target_": "clear_lewm.dinowm_gd.DINOWMGDPlanner",
+        "model": "???",
+        "n_steps": 1000,
+        "batch_size": 1,
+        "num_samples": 1,
+        "action_noise": 0.003,
+        "device": "cuda",
+        "seed": "${seed}",
+        "lr": 1.0,
+    }
+
+
+def _terminal_latent_mean_cost(
+    predicted: torch.Tensor, goal: torch.Tensor
+) -> torch.Tensor:
+    """DINO-WM's terminal visual-latent MSE, reduced per environment/sample."""
+    if goal.ndim == predicted.ndim - 1:
+        goal = goal.unsqueeze(1)
+    goal = goal[..., -1:, :].expand_as(predicted)
+    return functional.mse_loss(
+        predicted[..., -1:, :],
+        goal[..., -1:, :].detach(),
+        reduction="none",
+    ).mean(dim=tuple(range(2, predicted.ndim)))
+
+
+def install_terminal_latent_mean_criterion(model: Any) -> None:
+    """Use DINO-WM's mean-reduced visual objective with a LeWM model."""
+
+    def criterion(self, info_dict: dict, action_candidates=None):
+        del action_candidates
+        if "predicted_emb" in info_dict:
+            predicted = info_dict["predicted_emb"]
+            goal = info_dict["goal_emb"]
+        else:
+            predicted = info_dict["predicted_pixels_embed"]
+            goal = info_dict["pixels_goal_embed"]
+        return _terminal_latent_mean_cost(predicted, goal)
+
+    model.criterion = MethodType(criterion, model)
+
+
+class DINOWMGDPlanner(torch.nn.Module):
+    """Adapt DINO-WM's manual SGD update to stable-worldmodel's Solver API."""
+
+    def __init__(
+        self,
+        model: Any,
+        n_steps: int = 1000,
+        batch_size: int = 1,
+        num_samples: int = 1,
+        action_noise: float = 0.003,
+        device: str | torch.device = "cuda",
+        seed: int = 1234,
+        lr: float = 1.0,
+    ) -> None:
+        super().__init__()
+        if n_steps <= 0 or batch_size <= 0:
+            raise ValueError("n_steps and batch_size must be positive")
+        if num_samples != 1:
+            raise ValueError("DINO-WM GD requires num_samples=1")
+        if lr < 0 or action_noise < 0:
+            raise ValueError("lr and action_noise must be non-negative")
+
+        self.model = model
+        self.n_steps = int(n_steps)
+        self.batch_size = int(batch_size)
+        self.num_samples = int(num_samples)
+        self.action_noise = float(action_noise)
+        self.device = torch.device(device)
+        self.seed = int(seed)
+        self.lr = float(lr)
+        self.torch_gen = torch.Generator(device=self.device).manual_seed(self.seed)
+        try:
+            self._dtype = next(model.parameters()).dtype
+        except (AttributeError, StopIteration):
+            self._dtype = torch.float32
+        self._configured = False
+
+    def configure(self, *, action_space: Any, n_envs: int, config: Any) -> None:
+        shape = tuple(action_space.shape)
+        if not shape:
+            raise ValueError("action_space.shape must not be empty")
+        single_shape = shape[1:] if len(shape) > 1 and shape[0] == n_envs else shape
+        self._single_action_dim = int(np.prod(single_shape))
+        self._n_envs = int(n_envs)
+        self._config = config
+        self._configured = True
+
+    @property
+    def n_envs(self) -> int:
+        return self._n_envs
+
+    @property
+    def horizon(self) -> int:
+        return int(self._config.horizon)
+
+    @property
+    def action_dim(self) -> int:
+        return self._single_action_dim * int(self._config.action_block)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return self.solve(*args, **kwargs)
+
+    def _initialize(
+        self, total_envs: int, init_action: torch.Tensor | None
+    ) -> torch.Tensor:
+        prefix = (
+            torch.zeros(
+                total_envs,
+                0,
+                self.action_dim,
+                device=self.device,
+                dtype=self._dtype,
+            )
+            if init_action is None
+            else torch.as_tensor(init_action, device=self.device, dtype=self._dtype)
+        )
+        if prefix.ndim != 3 or prefix.shape[0] != total_envs:
+            raise ValueError("init_action must have shape (batch, time, action_dim)")
+        if prefix.shape[2] != self.action_dim or prefix.shape[1] > self.horizon:
+            raise ValueError("init_action does not match configured horizon/action_dim")
+        tail = torch.randn(
+            total_envs,
+            self.horizon - prefix.shape[1],
+            self.action_dim,
+            generator=self.torch_gen,
+            device=self.device,
+            dtype=self._dtype,
+        )
+        return torch.cat((prefix, tail), dim=1).unsqueeze(1)
+
+    def _expand_info(
+        self, info_dict: dict[str, Any], start: int, end: int
+    ) -> dict[str, Any]:
+        expanded = {}
+        for key, value in info_dict.items():
+            if torch.is_tensor(value):
+                value = value[start:end].to(self.device)
+                if value.is_floating_point():
+                    value = value.to(self._dtype)
+                expanded[key] = value.unsqueeze(1)
+            elif isinstance(value, np.ndarray):
+                expanded[key] = value[start:end, None, ...]
+            elif isinstance(value, (list, tuple)):
+                expanded[key] = value[start:end]
+            else:
+                expanded[key] = value
+        return expanded
+
+    def solve(
+        self, info_dict: dict[str, Any], init_action: torch.Tensor | None = None
+    ) -> dict[str, Any]:
+        if not self._configured:
+            raise RuntimeError("configure() must be called before solve()")
+
+        started = time.perf_counter()
+        initial = self._initialize(self.n_envs, init_action)
+        selected = []
+        histories = []
+
+        for start in range(0, self.n_envs, self.batch_size):
+            end = min(start + self.batch_size, self.n_envs)
+            actions = initial[start:end].clone().detach().requires_grad_(True)
+            optimizer = torch.optim.SGD([actions], lr=self.lr)
+            batch_info = self._expand_info(info_dict, start, end)
+            history = []
+
+            for _ in range(self.n_steps):
+                optimizer.zero_grad()
+                costs = self.model.get_cost(dict(batch_info), actions)
+                expected = (end - start, 1)
+                if not torch.is_tensor(costs) or tuple(costs.shape) != expected:
+                    raise ValueError(f"model cost shape must be {expected}")
+                total_loss = costs.mean() * (end - start)
+                total_loss.backward()
+                with torch.no_grad():
+                    actions_new = (
+                        actions - optimizer.param_groups[0]["lr"] * actions.grad
+                    )
+                    if self.action_noise:
+                        noise = torch.randn(
+                            actions.shape,
+                            generator=self.torch_gen,
+                            device=self.device,
+                            dtype=actions.dtype,
+                        )
+                        actions_new.add_(noise, alpha=self.action_noise)
+                    actions.copy_(actions_new)
+                history.append(float(total_loss.detach().cpu()))
+
+            selected.append(actions.detach()[:, 0].cpu())
+            histories.append(history)
+
+        return {
+            "actions": torch.cat(selected, dim=0),
+            "cost": histories,
+            "solve_time_s": time.perf_counter() - started,
+        }
+
+
+__all__ = [
+    "DINO_WM_SOURCE",
+    "DINOWMGDPlanner",
+    "install_terminal_latent_mean_criterion",
+    "solver_config",
+]

--- a/clear_lewm/dinowm_gd.py
+++ b/clear_lewm/dinowm_gd.py
@@ -178,12 +178,21 @@ class DINOWMGDPlanner(torch.nn.Module):
             raise RuntimeError("configure() must be called before solve()")
 
         started = time.perf_counter()
-        initial = self._initialize(self.n_envs, init_action)
+        if init_action is not None:
+            total_envs = int(init_action.shape[0])
+        else:
+            try:
+                total_envs = len(info_dict["pixels"])
+            except (KeyError, TypeError) as exc:
+                raise ValueError(
+                    "info_dict['pixels'] must expose the current batch size"
+                ) from exc
+        initial = self._initialize(total_envs, init_action)
         selected = []
         histories = []
 
-        for start in range(0, self.n_envs, self.batch_size):
-            end = min(start + self.batch_size, self.n_envs)
+        for start in range(0, total_envs, self.batch_size):
+            end = min(start + self.batch_size, total_envs)
             actions = initial[start:end].clone().detach().requires_grad_(True)
             optimizer = torch.optim.SGD([actions], lr=self.lr)
             batch_info = self._expand_info(info_dict, start, end)

--- a/clear_lewm/environment.py
+++ b/clear_lewm/environment.py
@@ -134,7 +134,7 @@ def collect_environment(torch_module=None, task: str | None = None) -> dict:
         import mujoco
 
         mujoco_runtime = mujoco.mj_versionString()
-    except (ImportError, OSError):
+    except (AttributeError, ImportError, OSError):
         mujoco_runtime = None
 
     physics = {

--- a/clear_lewm/runner.py
+++ b/clear_lewm/runner.py
@@ -236,7 +236,10 @@ def _compose_config(task: str, upstream_dir: Path, planner: str = "cem"):
     overrides = [f"solver={planner}"] if planner == "adam" else []
     with initialize_config_dir(version_base=None, config_dir=str(config_dir.resolve())):
         cfg = compose(config_name=task, overrides=overrides)
-    if planner == "dinowm-gd":
+    if planner == "adam":
+        with open_dict(cfg):
+            cfg.solver._target_ = "clear_lewm.adam.DeviceSafeGradientSolver"
+    elif planner == "dinowm-gd":
         from .dinowm_gd import solver_config as dinowm_gd_solver_config
 
         with open_dict(cfg):
@@ -508,6 +511,13 @@ def evaluate_manifest(
         raise ValueError("--planner only applies to world-model planning")
     if planner != "cem" and topk is not None:
         raise ValueError("--topk is only supported by the CEM planner")
+    if policy == "random" and planner != "cem":
+        raise ValueError("--planner requires a world-model policy")
+    if planner == "dinowm-gd" and actor_warmstart is True:
+        raise ValueError(
+            "--planner dinowm-gd does not support actor-prior initialization; "
+            "use --actor-warmstart off"
+        )
     if direct_target_mode not in {"query", "goal", "query_horizon"}:
         raise ValueError(f"Unknown direct target mode: {direct_target_mode}")
     if inference_mode == "direct" and actor_warmstart is False:
@@ -649,11 +659,12 @@ def evaluate_manifest(
         model = model.to("cuda").eval()
         model.requires_grad_(False)
         model.interpolate_pos_encoding = True
-        requested_actor_warmstart = (
-            True
-            if inference_mode == "direct" and actor_warmstart is None
-            else actor_warmstart
-        )
+        if inference_mode == "direct" and actor_warmstart is None:
+            requested_actor_warmstart = True
+        elif planner == "dinowm-gd" and actor_warmstart is None:
+            requested_actor_warmstart = False
+        else:
+            requested_actor_warmstart = actor_warmstart
         if requested_actor_warmstart is not None:
             if hasattr(model, "set_actor_warmstart"):
                 model.set_actor_warmstart(requested_actor_warmstart)
@@ -662,6 +673,10 @@ def evaluate_manifest(
         actor_warmstart_effective = getattr(model, "actor_warmstart", None)
         if actor_warmstart_effective is not None:
             actor_warmstart_effective = bool(actor_warmstart_effective)
+        if planner == "dinowm-gd":
+            # This solver initializes its own action tensor and never invokes
+            # the model's action head, even when the model exposes one.
+            actor_warmstart_effective = False
         batched_criterion_patch = False
         canonical_lewm = (
             type(model).__module__ == "stable_worldmodel.wm.lewm.lewm"
@@ -742,7 +757,11 @@ def evaluate_manifest(
         "n_steps": OmegaConf.select(cfg, "solver.n_steps"),
         "topk": OmegaConf.select(cfg, "solver.topk"),
     }
-    if planner == "dinowm-gd":
+    if planner == "adam":
+        from .adam import solver_provenance
+
+        solver_record.update(solver_provenance())
+    elif planner == "dinowm-gd":
         from .dinowm_gd import DINO_WM_SOURCE
 
         solver_record.update(
@@ -752,6 +771,10 @@ def evaluate_manifest(
                 "objective": "terminal_visual_latent_mse_mean",
                 "source": DINO_WM_SOURCE,
                 "update": "manual-sgd",
+                "initialization": "random-normal",
+                "actor_prior_initialization": False,
+                "model_scope": "LeWM visual latents",
+                "diagnostics": solver.diagnostics(),
             }
         )
     result = {

--- a/clear_lewm/runner.py
+++ b/clear_lewm/runner.py
@@ -32,6 +32,7 @@ OFFICIAL_DATASETS = {
 }
 
 BENCHMARK_VERSION = "v0.8"
+PLANNERS = ("cem", "adam")
 
 
 def _json_safe(value):
@@ -223,12 +224,17 @@ def _image_transform(image_size: int):
     )
 
 
-def _compose_config(task: str, upstream_dir: Path):
+def _compose_config(task: str, upstream_dir: Path, planner: str = "cem"):
     from hydra import compose, initialize_config_dir
 
+    if planner not in PLANNERS:
+        raise ValueError(
+            f"Unknown planner: {planner}. Expected one of: {', '.join(PLANNERS)}"
+        )
     config_dir = upstream_dir / "config" / "eval"
+    overrides = [] if planner == "cem" else [f"solver={planner}"]
     with initialize_config_dir(version_base=None, config_dir=str(config_dir.resolve())):
-        return compose(config_name=task)
+        return compose(config_name=task, overrides=overrides)
 
 
 def _install_cube_success(
@@ -482,10 +488,19 @@ def evaluate_manifest(
     matmul_precision: str | None = None,
     strict_checkpoint: bool = False,
     allow_modified_stable_worldmodel: bool = False,
+    planner: str = "cem",
 ) -> dict:
     run_started = time.perf_counter()
     if inference_mode not in {"cem", "direct"}:
         raise ValueError(f"Unknown inference mode: {inference_mode}")
+    if planner not in PLANNERS:
+        raise ValueError(
+            f"Unknown planner: {planner}. Expected one of: {', '.join(PLANNERS)}"
+        )
+    if inference_mode == "direct" and planner != "cem":
+        raise ValueError("--planner only applies to world-model planning")
+    if planner != "cem" and topk is not None:
+        raise ValueError("--topk is only supported by the CEM planner")
     if direct_target_mode not in {"query", "goal", "query_horizon"}:
         raise ValueError(f"Unknown direct target mode: {direct_target_mode}")
     if inference_mode == "direct" and actor_warmstart is False:
@@ -544,7 +559,7 @@ def evaluate_manifest(
     _seed_everything(seed, cpu_threads=cpu_threads)
     if matmul_precision is not None:
         torch.set_float32_matmul_precision(matmul_precision)
-    cfg = _compose_config(task, upstream_dir)
+    cfg = _compose_config(task, upstream_dir, planner=planner)
     with open_dict(cfg):
         cfg.eval.num_eval = len(manifest["pairs"])
         cfg.eval.goal_offset_steps = int(protocol.goal_offset)
@@ -750,11 +765,11 @@ def evaluate_manifest(
             "mode": (
                 "direct"
                 if inference_mode == "direct"
-                else "pure-cem"
+                else f"pure-{planner}"
                 if actor_warmstart_effective is False
-                else "prior-initialized-cem"
+                else f"prior-initialized-{planner}"
                 if actor_warmstart_effective is True
-                else "cem"
+                else planner
             ),
             "actor_warmstart_requested": requested_actor_warmstart,
             "actor_warmstart_effective": actor_warmstart_effective,

--- a/clear_lewm/runner.py
+++ b/clear_lewm/runner.py
@@ -32,7 +32,7 @@ OFFICIAL_DATASETS = {
 }
 
 BENCHMARK_VERSION = "v0.8"
-PLANNERS = ("cem", "adam")
+PLANNERS = ("cem", "adam", "dinowm-gd")
 
 
 def _json_safe(value):
@@ -226,15 +226,22 @@ def _image_transform(image_size: int):
 
 def _compose_config(task: str, upstream_dir: Path, planner: str = "cem"):
     from hydra import compose, initialize_config_dir
+    from omegaconf import OmegaConf, open_dict
 
     if planner not in PLANNERS:
         raise ValueError(
             f"Unknown planner: {planner}. Expected one of: {', '.join(PLANNERS)}"
         )
     config_dir = upstream_dir / "config" / "eval"
-    overrides = [] if planner == "cem" else [f"solver={planner}"]
+    overrides = [f"solver={planner}"] if planner == "adam" else []
     with initialize_config_dir(version_base=None, config_dir=str(config_dir.resolve())):
-        return compose(config_name=task, overrides=overrides)
+        cfg = compose(config_name=task, overrides=overrides)
+    if planner == "dinowm-gd":
+        from .dinowm_gd import solver_config as dinowm_gd_solver_config
+
+        with open_dict(cfg):
+            cfg.solver = OmegaConf.create(dinowm_gd_solver_config())
+    return cfg
 
 
 def _install_cube_success(
@@ -660,7 +667,11 @@ def evaluate_manifest(
             type(model).__module__ == "stable_worldmodel.wm.lewm.lewm"
             and type(model).__name__ == "LeWM"
         )
-        if int(cfg.solver.batch_size) > 1 and canonical_lewm:
+        if planner == "dinowm-gd":
+            from .dinowm_gd import install_terminal_latent_mean_criterion
+
+            install_terminal_latent_mean_criterion(model)
+        elif int(cfg.solver.batch_size) > 1 and canonical_lewm:
             _install_batched_lewm_criterion(model)
             batched_criterion_patch = True
         checkpoint = _checkpoint_record(policy, data_root)
@@ -722,6 +733,24 @@ def evaluate_manifest(
     summary.pop("final_state_success_rate_percent", None)
     summary.pop("sustained_success_rate_percent", None)
     summary.pop("sustained_steps", None)
+    solver_record = {
+        "batch_size": OmegaConf.select(cfg, "solver.batch_size"),
+        "num_samples": OmegaConf.select(cfg, "solver.num_samples"),
+        "n_steps": OmegaConf.select(cfg, "solver.n_steps"),
+        "topk": OmegaConf.select(cfg, "solver.topk"),
+    }
+    if planner == "dinowm-gd":
+        from .dinowm_gd import DINO_WM_SOURCE
+
+        solver_record.update(
+            {
+                "action_noise": OmegaConf.select(cfg, "solver.action_noise"),
+                "learning_rate": OmegaConf.select(cfg, "solver.lr"),
+                "objective": "terminal_visual_latent_mse_mean",
+                "source": DINO_WM_SOURCE,
+                "update": "manual-sgd",
+            }
+        )
     result = {
         "schema_version": "clear-lewm-result-v1",
         "benchmark_version": BENCHMARK_VERSION,
@@ -755,12 +784,7 @@ def evaluate_manifest(
             "tworoom_collision_mode": protocol.tworoom_collision_mode,
             "sustained_steps": protocol.hold_steps(task),
         },
-        "solver": {
-            "batch_size": OmegaConf.select(cfg, "solver.batch_size"),
-            "num_samples": OmegaConf.select(cfg, "solver.num_samples"),
-            "n_steps": OmegaConf.select(cfg, "solver.n_steps"),
-            "topk": OmegaConf.select(cfg, "solver.topk"),
-        },
+        "solver": solver_record,
         "inference": {
             "mode": (
                 "direct"

--- a/clear_lewm/runner.py
+++ b/clear_lewm/runner.py
@@ -667,11 +667,14 @@ def evaluate_manifest(
             type(model).__module__ == "stable_worldmodel.wm.lewm.lewm"
             and type(model).__name__ == "LeWM"
         )
+        legacy_lewm = (
+            type(model).__module__ == "jepa" and type(model).__name__ == "JEPA"
+        )
         if planner == "dinowm-gd":
             from .dinowm_gd import install_terminal_latent_mean_criterion
 
             install_terminal_latent_mean_criterion(model)
-        elif int(cfg.solver.batch_size) > 1 and canonical_lewm:
+        elif int(cfg.solver.batch_size) > 1 and (canonical_lewm or legacy_lewm):
             _install_batched_lewm_criterion(model)
             batched_criterion_patch = True
         checkpoint = _checkpoint_record(policy, data_root)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 import pytest
 
 from clear_lewm import environment
@@ -24,6 +27,12 @@ def test_environment_record_covers_task_physics_and_numerics():
         "policy",
         "world",
     }
+
+
+def test_environment_record_survives_broken_optional_mujoco_import(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mujoco", SimpleNamespace())
+    record = collect_environment(task="pusht")
+    assert record["physics"]["mujoco_runtime"] is None
 
 
 def test_official_runtime_audit_rejects_source_drift(monkeypatch):

--- a/tests/test_planner_gpu_regression.py
+++ b/tests/test_planner_gpu_regression.py
@@ -1,0 +1,149 @@
+"""Opt-in real-checkpoint GPU regression for the experimental planners.
+
+Set ``CLEAR_LEWM_RUN_GPU_REGRESSION=1``, ``CLEAR_LEWM_GPU_DATASET``, and
+``CLEAR_LEWM_GPU_CACHE_DIR`` before running this module with pytest.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from importlib.metadata import version
+from pathlib import Path
+
+import pytest
+
+from clear_lewm.runner import evaluate_manifest
+
+RUN_GPU_REGRESSION = os.environ.get("CLEAR_LEWM_RUN_GPU_REGRESSION") == "1"
+
+
+def _require_path(variable: str) -> Path:
+    value = os.environ.get(variable)
+    if value is None:
+        pytest.fail(f"{variable} must be set for the GPU regression")
+    path = Path(value).resolve()
+    if not path.exists():
+        pytest.fail(f"{variable} does not exist: {path}")
+    return path
+
+
+def _two_pair_manifest(tmp_path: Path) -> Path:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "manifests"
+        / "v0.8"
+        / "pusht"
+        / "moderate-seed0-n100.json"
+    )
+    manifest = json.loads(source.read_text())
+    manifest["pairs"] = manifest["pairs"][:2]
+    manifest["statistics"]["num_eval"] = 2
+    output = tmp_path / "pusht-moderate-seed0-n2.json"
+    output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return output
+
+
+def _assert_same_core_result(first: dict, second: dict) -> None:
+    for key in (
+        "task",
+        "protocol",
+        "policy",
+        "checkpoint",
+        "policy_seed",
+        "dataset_name",
+        "dataset_fingerprint",
+        "criterion",
+        "metrics",
+        "episode_successes",
+        "raw_world_metrics",
+    ):
+        assert first[key] == second[key], key
+
+
+@pytest.mark.skipif(
+    not RUN_GPU_REGRESSION,
+    reason="set CLEAR_LEWM_RUN_GPU_REGRESSION=1 for the real-checkpoint smoke",
+)
+def test_official_pusht_checkpoint_planners_on_stable_worldmodel_010(tmp_path):
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("stable_worldmodel")
+    assert torch.cuda.is_available(), "the real-checkpoint regression requires CUDA"
+    assert version("stable-worldmodel") == "0.1.0"
+
+    dataset = _require_path("CLEAR_LEWM_GPU_DATASET")
+    cache_dir = _require_path("CLEAR_LEWM_GPU_CACHE_DIR")
+    upstream = Path(__file__).resolve().parents[1] / "third_party" / "le-wm"
+    manifest = _two_pair_manifest(tmp_path)
+    policy = os.environ.get("CLEAR_LEWM_GPU_POLICY", "official/pusht")
+    common = {
+        "manifest_path": manifest,
+        "policy": policy,
+        "cache_dir": cache_dir,
+        "dataset_path": dataset,
+        "upstream_dir": upstream,
+        "policy_seed": 0,
+        "actor_warmstart": False,
+        "solver_batch_size": 1,
+        "cpu_threads": 1,
+        "matmul_precision": "highest",
+        "strict_checkpoint": True,
+    }
+
+    default_cem = evaluate_manifest(
+        **common,
+        output=tmp_path / "cem-default.json",
+        num_samples=4,
+        n_steps=2,
+        topk=2,
+    )
+    explicit_cem = evaluate_manifest(
+        **common,
+        output=tmp_path / "cem-explicit.json",
+        planner="cem",
+        num_samples=4,
+        n_steps=2,
+        topk=2,
+    )
+    _assert_same_core_result(default_cem, explicit_cem)
+
+    adam = evaluate_manifest(
+        **common,
+        output=tmp_path / "adam.json",
+        planner="adam",
+        num_samples=2,
+        n_steps=2,
+    )
+    assert adam["inference"]["solver_target"] == (
+        "clear_lewm.adam.DeviceSafeGradientSolver"
+    )
+    assert adam["solver"]["source"]["version"] == "0.1.0"
+    assert adam["environment"]["execution"]["status"] == "verified"
+    assert adam["environment"]["accelerator"] is not None
+
+    dino_common = dict(common)
+    dino_common.pop("actor_warmstart")
+    dino_runs = [
+        evaluate_manifest(
+            **dino_common,
+            output=tmp_path / f"dinowm-gd-{run}.json",
+            planner="dinowm-gd",
+            num_samples=1,
+            n_steps=10,
+        )
+        for run in range(2)
+    ]
+    _assert_same_core_result(*dino_runs)
+    for result in dino_runs:
+        diagnostics = result["solver"]["diagnostics"]
+        assert diagnostics["solve_calls"] > 0
+        assert diagnostics["finite_actions"] is True
+        assert diagnostics["finite_costs"] is True
+        assert diagnostics["total_solve_time_s"] > 0.0
+        assert result["solver"]["initialization"] == "random-normal"
+        assert result["solver"]["actor_prior_initialization"] is False
+        assert result["inference"]["actor_warmstart_requested"] is False
+        assert result["inference"]["actor_warmstart_effective"] is False
+        assert result["inference"]["mode"] == "pure-dinowm-gd"
+        assert result["environment"]["execution"]["status"] == "verified"
+        assert result["environment"]["accelerator"] is not None

--- a/tests/test_runner_success.py
+++ b/tests/test_runner_success.py
@@ -395,6 +395,30 @@ def test_dinowm_manual_sgd_matches_paper_update():
     assert torch.allclose(result["actions"], expected)
 
 
+def test_dinowm_solver_uses_the_current_active_environment_count():
+    torch = pytest.importorskip("torch")
+    from clear_lewm.dinowm_gd import DINOWMGDPlanner
+
+    class QuadraticModel(torch.nn.Module):
+        def get_cost(self, info_dict, actions):
+            return actions.pow(2).mean(dim=(2, 3))
+
+    planner = DINOWMGDPlanner(
+        QuadraticModel(),
+        n_steps=1,
+        batch_size=2,
+        action_noise=0.0,
+        device="cpu",
+    )
+    planner.configure(
+        action_space=SimpleNamespace(shape=(4, 1)),
+        n_envs=4,
+        config=SimpleNamespace(horizon=2, action_block=1),
+    )
+    result = planner.solve({"pixels": torch.zeros(3, 1)})
+    assert result["actions"].shape == (3, 2, 1)
+
+
 def test_dinowm_profile_uses_published_defaults():
     pytest.importorskip("torch")
     from clear_lewm.dinowm_gd import solver_config

--- a/tests/test_runner_success.py
+++ b/tests/test_runner_success.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -13,12 +14,14 @@ from clear_lewm.protocols import get_protocol
 from clear_lewm.runner import (
     _audit_checkpoint_state,
     _checkpoint_record,
+    _compose_config,
     _install_batched_lewm_criterion,
     _install_pusht_success,
     _install_reacher_success,
     _install_tworoom_success,
     _load_paired_random_trace,
     _portable_manifest_path,
+    evaluate_manifest,
 )
 from clear_lewm.runtime import audit_hydra_targets, configure_import_paths
 
@@ -323,6 +326,35 @@ def test_actor_warmstart_cli_is_explicit_and_defaults_to_auto():
         parser.parse_args([*common, "--actor-warmstart", "off"]).actor_warmstart
         == "off"
     )
+
+
+def test_planner_cli_defaults_to_cem_and_accepts_adam():
+    parser = build_parser()
+    common = ["evaluate", "--manifest", "manifest.json", "--output", "out.json"]
+    assert parser.parse_args(common).planner == "cem"
+    assert parser.parse_args([*common, "--planner", "adam"]).planner == "adam"
+
+
+def test_compose_config_selects_upstream_planner():
+    pytest.importorskip("hydra")
+    upstream = Path(__file__).resolve().parents[1] / "third_party" / "le-wm"
+    cem = _compose_config("pusht", upstream, planner="cem")
+    adam = _compose_config("pusht", upstream, planner="adam")
+    assert cem.solver._target_ == "stable_worldmodel.solver.CEMSolver"
+    assert adam.solver._target_ == "stable_worldmodel.solver.GradientSolver"
+
+
+def test_non_cem_planner_rejects_cem_only_options(tmp_path):
+    common = {
+        "manifest_path": tmp_path / "missing.json",
+        "policy": "random",
+        "output": tmp_path / "out.json",
+        "planner": "adam",
+    }
+    with pytest.raises(ValueError, match="world-model planning"):
+        evaluate_manifest(**common, inference_mode="direct")
+    with pytest.raises(ValueError, match="only supported by the CEM"):
+        evaluate_manifest(**common, topk=30)
 
 
 def test_direct_cli_records_an_explicit_target_mode():

--- a/tests/test_runner_success.py
+++ b/tests/test_runner_success.py
@@ -336,15 +336,21 @@ def test_planner_cli_defaults_to_cem_and_accepts_alternatives():
     assert parser.parse_args([*common, "--planner", "dinowm-gd"]).planner == "dinowm-gd"
 
 
-def test_compose_config_selects_upstream_planner():
+def test_compose_config_preserves_default_cem_and_selects_alternatives():
     pytest.importorskip("hydra")
     pytest.importorskip("torch")
+    from omegaconf import OmegaConf
+
     upstream = Path(__file__).resolve().parents[1] / "third_party" / "le-wm"
-    cem = _compose_config("pusht", upstream, planner="cem")
+    default_cem = _compose_config("pusht", upstream)
+    explicit_cem = _compose_config("pusht", upstream, planner="cem")
     adam = _compose_config("pusht", upstream, planner="adam")
     dinowm_gd = _compose_config("pusht", upstream, planner="dinowm-gd")
-    assert cem.solver._target_ == "stable_worldmodel.solver.CEMSolver"
-    assert adam.solver._target_ == "stable_worldmodel.solver.GradientSolver"
+    assert OmegaConf.to_container(default_cem, resolve=True) == OmegaConf.to_container(
+        explicit_cem, resolve=True
+    )
+    assert explicit_cem.solver._target_ == "stable_worldmodel.solver.CEMSolver"
+    assert adam.solver._target_ == "clear_lewm.adam.DeviceSafeGradientSolver"
     assert dinowm_gd.solver._target_ == "clear_lewm.dinowm_gd.DINOWMGDPlanner"
     assert dinowm_gd.solver.n_steps == 1000
     assert dinowm_gd.solver.lr == 1.0
@@ -393,6 +399,47 @@ def test_dinowm_manual_sgd_matches_paper_update():
     expected = expected_initial - 0.1 * (expected_initial - 1.0)
     result = planner.solve({"pixels": torch.zeros(2, 1)})
     assert torch.allclose(result["actions"], expected)
+    assert np.isfinite(result["cost"]).all()
+    assert result["solve_time_s"] >= 0.0
+    assert planner.diagnostics() == {
+        "solve_calls": 1,
+        "total_solve_time_s": result["solve_time_s"],
+        "finite_actions": True,
+        "finite_costs": True,
+    }
+
+
+def test_dinowm_manual_sgd_is_deterministic_for_a_fixed_seed():
+    torch = pytest.importorskip("torch")
+    from clear_lewm.dinowm_gd import DINOWMGDPlanner
+
+    class QuadraticModel(torch.nn.Module):
+        def get_cost(self, info_dict, actions):
+            return (actions - 0.25).pow(2).mean(dim=(2, 3))
+
+    def run_once():
+        planner = DINOWMGDPlanner(
+            QuadraticModel(),
+            n_steps=3,
+            batch_size=2,
+            action_noise=0.003,
+            device="cpu",
+            seed=17,
+            lr=0.1,
+        )
+        planner.configure(
+            action_space=SimpleNamespace(shape=(2, 1)),
+            n_envs=2,
+            config=SimpleNamespace(horizon=2, action_block=1),
+        )
+        return planner.solve({"pixels": torch.zeros(2, 1)})
+
+    first = run_once()
+    second = run_once()
+    assert torch.equal(first["actions"], second["actions"])
+    assert first["cost"] == second["cost"]
+    assert torch.isfinite(first["actions"]).all()
+    assert np.isfinite(first["cost"]).all()
 
 
 def test_dinowm_solver_uses_the_current_active_environment_count():
@@ -436,6 +483,40 @@ def test_dinowm_profile_uses_published_defaults():
     }
 
 
+def test_adam_full_horizon_initialization_stays_on_the_solver_device():
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("stable_worldmodel")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required to exercise the upstream device mismatch")
+
+    from clear_lewm.adam import DeviceSafeGradientSolver
+
+    model = torch.nn.Linear(1, 1, bias=False).to("cuda")
+    planner = DeviceSafeGradientSolver(
+        model,
+        n_steps=1,
+        batch_size=1,
+        num_samples=2,
+        var_scale=1.0,
+        device="cuda",
+        seed=11,
+    )
+    planner.configure(
+        action_space=SimpleNamespace(shape=(2, 1)),
+        n_envs=2,
+        config=SimpleNamespace(horizon=2, action_block=1),
+    )
+    full_horizon_cpu = torch.zeros(2, 2, 1, device="cpu")
+
+    with torch.no_grad():
+        planner.init_action(2, full_horizon_cpu)
+
+    assert planner.init.device.type == "cuda"
+    assert planner.init.shape == (2, 2, 2, 1)
+    assert torch.equal(planner.init[:, 0].cpu(), full_horizon_cpu)
+    assert torch.isfinite(planner.init).all()
+
+
 def test_non_cem_planner_rejects_cem_only_options(tmp_path):
     common = {
         "manifest_path": tmp_path / "missing.json",
@@ -447,6 +528,17 @@ def test_non_cem_planner_rejects_cem_only_options(tmp_path):
         evaluate_manifest(**common, inference_mode="direct")
     with pytest.raises(ValueError, match="only supported by the CEM"):
         evaluate_manifest(**common, topk=30)
+
+
+def test_dinowm_planner_rejects_actor_prior_initialization(tmp_path):
+    with pytest.raises(ValueError, match="does not support actor-prior"):
+        evaluate_manifest(
+            manifest_path=tmp_path / "missing.json",
+            policy="official/pusht",
+            output=tmp_path / "out.json",
+            planner="dinowm-gd",
+            actor_warmstart=True,
+        )
 
 
 def test_direct_cli_records_an_explicit_target_mode():

--- a/tests/test_runner_success.py
+++ b/tests/test_runner_success.py
@@ -328,20 +328,88 @@ def test_actor_warmstart_cli_is_explicit_and_defaults_to_auto():
     )
 
 
-def test_planner_cli_defaults_to_cem_and_accepts_adam():
+def test_planner_cli_defaults_to_cem_and_accepts_alternatives():
     parser = build_parser()
     common = ["evaluate", "--manifest", "manifest.json", "--output", "out.json"]
     assert parser.parse_args(common).planner == "cem"
     assert parser.parse_args([*common, "--planner", "adam"]).planner == "adam"
+    assert parser.parse_args([*common, "--planner", "dinowm-gd"]).planner == "dinowm-gd"
 
 
 def test_compose_config_selects_upstream_planner():
     pytest.importorskip("hydra")
+    pytest.importorskip("torch")
     upstream = Path(__file__).resolve().parents[1] / "third_party" / "le-wm"
     cem = _compose_config("pusht", upstream, planner="cem")
     adam = _compose_config("pusht", upstream, planner="adam")
+    dinowm_gd = _compose_config("pusht", upstream, planner="dinowm-gd")
     assert cem.solver._target_ == "stable_worldmodel.solver.CEMSolver"
     assert adam.solver._target_ == "stable_worldmodel.solver.GradientSolver"
+    assert dinowm_gd.solver._target_ == "clear_lewm.dinowm_gd.DINOWMGDPlanner"
+    assert dinowm_gd.solver.n_steps == 1000
+    assert dinowm_gd.solver.lr == 1.0
+    assert dinowm_gd.solver.action_noise == 0.003
+
+
+def test_dinowm_objective_means_over_terminal_latent_dimensions():
+    torch = pytest.importorskip("torch")
+    from clear_lewm.dinowm_gd import _terminal_latent_mean_cost
+
+    predicted = torch.ones(2, 3, 4, 192)
+    goal = torch.zeros(2, 4, 192)
+    cost = _terminal_latent_mean_cost(predicted, goal)
+    assert cost.shape == (2, 3)
+    assert torch.equal(cost, torch.ones(2, 3))
+
+
+def test_dinowm_manual_sgd_matches_paper_update():
+    torch = pytest.importorskip("torch")
+    from clear_lewm.dinowm_gd import DINOWMGDPlanner
+
+    class QuadraticModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.anchor = torch.nn.Parameter(torch.zeros(()))
+
+        def get_cost(self, info_dict, actions):
+            return (actions - 1.0).pow(2).mean(dim=(2, 3))
+
+    model = QuadraticModel()
+    planner = DINOWMGDPlanner(
+        model,
+        n_steps=1,
+        batch_size=2,
+        action_noise=0.0,
+        device="cpu",
+        seed=7,
+        lr=0.1,
+    )
+    planner.configure(
+        action_space=SimpleNamespace(shape=(2, 1)),
+        n_envs=2,
+        config=SimpleNamespace(horizon=2, action_block=1),
+    )
+    expected_initial = torch.randn(2, 2, 1, generator=torch.Generator().manual_seed(7))
+    expected = expected_initial - 0.1 * (expected_initial - 1.0)
+    result = planner.solve({"pixels": torch.zeros(2, 1)})
+    assert torch.allclose(result["actions"], expected)
+
+
+def test_dinowm_profile_uses_published_defaults():
+    pytest.importorskip("torch")
+    from clear_lewm.dinowm_gd import solver_config
+
+    assert solver_config() == {
+        "_target_": "clear_lewm.dinowm_gd.DINOWMGDPlanner",
+        "model": "???",
+        "n_steps": 1000,
+        "batch_size": 1,
+        "num_samples": 1,
+        "action_noise": 0.003,
+        "device": "cuda",
+        "seed": "${seed}",
+        "lr": 1.0,
+    }
 
 
 def test_non_cem_planner_rejects_cem_only_options(tmp_path):


### PR DESCRIPTION
## Summary

- add an explicit `--planner` option while preserving CEM as the default
- expose the LeWM Adam profile through a narrow `stable-worldmodel==0.1.0`
  device-compatibility adapter
- add the DINO-WM optimizer profile for LeWM visual latents
- record planner scope, initialization, update rule, source, finite-value checks,
  and runtime provenance

## Scope

`dinowm-gd` applies DINO-WM's action-optimization profile to a LeWM world model;
it is not a reproduction of the DINO-WM model. It uses neither the DINO encoder
contract nor DINO-WM's proprioceptive objective. Actor-prior initialization is
unsupported: `--actor-warmstart on` is rejected and `auto` resolves to `off`.

Adam and DINO-style GD are experimental/non-reference planner profiles. This PR
makes no performance claim.

## Compatibility fix

The pinned `stable-worldmodel==0.1.0` Adam solver can receive a full-horizon CPU
initialization and then add CUDA sampling noise to it. The CLEAR adapter moves
that tensor to the configured solver device before retaining the upstream
initialization and optimization behavior.

## Validation

- `ruff check .` passes
- planner unit tests pass, including exact default-vs-explicit CEM config parity,
  the Adam CUDA initialization regression, fixed-seed DINO determinism, and
  finite DINO actions/losses
- the opt-in real-checkpoint GPU regression passes on the first two canonical
  PushT Moderate seed-0 pairs

Real-checkpoint smoke provenance:

- official `quentinll/lewm-pusht` revision
  `22b330c28c27ead4bfd1888615af1340e3fe9052`
- checkpoint SHA-256
  `48938400ae3464c9680731287f583a9cb516f55a8ec64ea13a91be47fb15b607`
- canonical dataset metadata fingerprint
  `8dabf107816dce322a4afb3f2c80bf2981e399b00bb37c52aac1fd068fa3dd00`
- verified official `stable-worldmodel==0.1.0` runtime, Torch 2.11.0+cu128,
  NVIDIA RTX PRO 6000 Blackwell Server Edition
- default and explicit CEM have identical episode traces and core result data
- Adam completes without the CPU/CUDA initialization mismatch
- two DINO-style 10-step runs have identical traces/core results; both record
  finite actions and losses, with aggregate solver times of 0.832 s and 0.845 s

All planners were intentionally run with a tiny smoke budget and produced 0/2;
these outcomes are correctness checks, not performance evidence.

## Reproduction

The GPU regression is opt-in so normal CPU CI remains lightweight:

```bash
CLEAR_LEWM_RUN_GPU_REGRESSION=1 \
CLEAR_LEWM_GPU_DATASET=/path/to/pusht_expert_train.h5 \
CLEAR_LEWM_GPU_CACHE_DIR=/path/to/cache \
pytest -q tests/test_planner_gpu_regression.py
```
